### PR TITLE
Add test suite using Swift Testing framework

### DIFF
--- a/Tetris.xcodeproj/project.pbxproj
+++ b/Tetris.xcodeproj/project.pbxproj
@@ -29,6 +29,10 @@
 		CDAD63142C1DFB6A00A260F1 /* GameControlButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAD62FB2C1DFB6A00A260F1 /* GameControlButtonStyle.swift */; };
 		CDAD63152C1DFB6A00A260F1 /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAD62FA2C1DFB6A00A260F1 /* Array.swift */; };
 		CDAD63172C1DFB7400A260F1 /* GameManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDAD63162C1DFB7400A260F1 /* GameManager.swift */; };
+		CDA100062C20000000AA0006 /* TetrominoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA100012C20000000AA0001 /* TetrominoTests.swift */; };
+		CDA100072C20000000AA0007 /* GameManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA100022C20000000AA0002 /* GameManagerTests.swift */; };
+		CDA100082C20000000AA0008 /* TetrominoFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA100032C20000000AA0003 /* TetrominoFactoryTests.swift */; };
+		CDA100092C20000000AA0009 /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA100042C20000000AA0004 /* ModelTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -56,10 +60,22 @@
 		CDAD63022C1DFB6A00A260F1 /* KeyboardInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardInputView.swift; sourceTree = "<group>"; };
 		CDAD63032C1DFB6A00A260F1 /* TetrominoPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TetrominoPreview.swift; sourceTree = "<group>"; };
 		CDAD63162C1DFB7400A260F1 /* GameManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameManager.swift; sourceTree = "<group>"; };
+		CDA100012C20000000AA0001 /* TetrominoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TetrominoTests.swift; sourceTree = "<group>"; };
+		CDA100022C20000000AA0002 /* GameManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameManagerTests.swift; sourceTree = "<group>"; };
+		CDA100032C20000000AA0003 /* TetrominoFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TetrominoFactoryTests.swift; sourceTree = "<group>"; };
+		CDA100042C20000000AA0004 /* ModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
+		CDA100052C20000000AA0005 /* TetrisTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TetrisTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		590074B62C1DFA4900A9C48F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CDA1000D2C20000000AA000D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -73,6 +89,7 @@
 			isa = PBXGroup;
 			children = (
 				590074BB2C1DFA4900A9C48F /* Tetris */,
+				CDA1000A2C20000000AA000A /* TetrisTests */,
 				590074BA2C1DFA4900A9C48F /* Products */,
 			);
 			sourceTree = "<group>";
@@ -81,6 +98,7 @@
 			isa = PBXGroup;
 			children = (
 				590074B92C1DFA4900A9C48F /* Tetris.app */,
+				CDA100052C20000000AA0005 /* TetrisTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -147,6 +165,17 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		CDA1000A2C20000000AA000A /* TetrisTests */ = {
+			isa = PBXGroup;
+			children = (
+				CDA100012C20000000AA0001 /* TetrominoTests.swift */,
+				CDA100022C20000000AA0002 /* GameManagerTests.swift */,
+				CDA100032C20000000AA0003 /* TetrominoFactoryTests.swift */,
+				CDA100042C20000000AA0004 /* ModelTests.swift */,
+			);
+			path = TetrisTests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -167,6 +196,24 @@
 			productReference = 590074B92C1DFA4900A9C48F /* Tetris.app */;
 			productType = "com.apple.product-type.application";
 		};
+		CDA1000B2C20000000AA000B /* TetrisTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CDA100112C20000000AA0011 /* Build configuration list for PBXNativeTarget "TetrisTests" */;
+			buildPhases = (
+				CDA1000C2C20000000AA000C /* Sources */,
+				CDA1000D2C20000000AA000D /* Frameworks */,
+				CDA1000E2C20000000AA000E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CDA100132C20000000AA0013 /* PBXTargetDependency */,
+			);
+			name = TetrisTests;
+			productName = TetrisTests;
+			productReference = CDA100052C20000000AA0005 /* TetrisTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -179,6 +226,10 @@
 				TargetAttributes = {
 					590074B82C1DFA4900A9C48F = {
 						CreatedOnToolsVersion = 15.4;
+					};
+					CDA1000B2C20000000AA000B = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = 590074B82C1DFA4900A9C48F;
 					};
 				};
 			};
@@ -196,6 +247,7 @@
 			projectRoot = "";
 			targets = (
 				590074B82C1DFA4900A9C48F /* Tetris */,
+				CDA1000B2C20000000AA000B /* TetrisTests */,
 			);
 		};
 /* End PBXProject section */
@@ -207,6 +259,13 @@
 			files = (
 				590074C52C1DFA4C00A9C48F /* Preview Assets.xcassets in Resources */,
 				590074C12C1DFA4C00A9C48F /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CDA1000E2C20000000AA000E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -240,7 +299,36 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CDA1000C2C20000000AA000C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CDA100062C20000000AA0006 /* TetrominoTests.swift in Sources */,
+				CDA100072C20000000AA0007 /* GameManagerTests.swift in Sources */,
+				CDA100082C20000000AA0008 /* TetrominoFactoryTests.swift in Sources */,
+				CDA100092C20000000AA0009 /* ModelTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXContainerItemProxy section */
+		CDA100122C20000000AA0012 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 590074B12C1DFA4900A9C48F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 590074B82C1DFA4900A9C48F;
+			remoteInfo = Tetris;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXTargetDependency section */
+		CDA100132C20000000AA0013 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 590074B82C1DFA4900A9C48F /* Tetris */;
+			targetProxy = CDA100122C20000000AA0012 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		590074C62C1DFA4C00A9C48F /* Debug */ = {
@@ -441,6 +529,52 @@
 			};
 			name = Release;
 		};
+		CDA1000F2C20000000AA000F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = CZ72YFTC2R;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.soliskit.TetrisTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Tetris.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Tetris";
+			};
+			name = Debug;
+		};
+		CDA100102C20000000AA0010 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = CZ72YFTC2R;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.soliskit.TetrisTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Tetris.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Tetris";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -458,6 +592,15 @@
 			buildConfigurations = (
 				590074C92C1DFA4C00A9C48F /* Debug */,
 				590074CA2C1DFA4C00A9C48F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CDA100112C20000000AA0011 /* Build configuration list for PBXNativeTarget "TetrisTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CDA1000F2C20000000AA000F /* Debug */,
+				CDA100102C20000000AA0010 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/TetrisTests/GameManagerTests.swift
+++ b/TetrisTests/GameManagerTests.swift
@@ -1,0 +1,169 @@
+//
+//  GameManagerTests.swift
+//  TetrisTests
+//
+//  Created by David Solis on 4/11/26.
+//
+
+import Testing
+@testable import Tetris
+
+@Suite("Game Manager")
+@MainActor
+struct GameManagerTests {
+
+    @Test func initialStateIsGameOver() {
+        let manager = GameManager()
+        #expect(manager.state == .gameOver)
+    }
+
+    @Test func initialScoreIsZero() {
+        let manager = GameManager()
+        #expect(manager.score == 0)
+        #expect(manager.level == 1)
+    }
+
+    @Test func initialBoardIsEmpty() {
+        let manager = GameManager()
+        let allEmpty = manager.gameBoard.allSatisfy { row in
+            row.allSatisfy { cell in
+                cell?.isFilled == false
+            }
+        }
+        #expect(allEmpty)
+    }
+
+    @Test func initialBoardDimensions() {
+        let manager = GameManager()
+        #expect(manager.gameBoard.count == 20)
+        #expect(manager.gameBoard.first?.count == 10)
+    }
+
+    @Test func newGameSetsPausedState() {
+        let manager = GameManager()
+        manager.handleAction(.newGame)
+        #expect(manager.state == .paused)
+    }
+
+    @Test func newGameResetsScore() {
+        let manager = GameManager()
+        manager.handleAction(.newGame)
+        #expect(manager.score == 0)
+        #expect(manager.level == 1)
+    }
+
+    @Test func newGameClearsHeldTetromino() {
+        let manager = GameManager()
+        manager.handleAction(.newGame)
+        #expect(manager.heldTetromino == nil)
+        #expect(manager.canHoldTetromino == true)
+    }
+
+    @Test func resumeSetsPlayingState() {
+        let manager = GameManager()
+        manager.handleAction(.newGame)
+        manager.handleAction(.resume)
+        #expect(manager.state == .playing)
+    }
+
+    @Test func pauseSetsPausedState() {
+        let manager = GameManager()
+        manager.handleAction(.newGame)
+        manager.handleAction(.resume)
+        manager.handleAction(.pause)
+        #expect(manager.state == .paused)
+    }
+
+    @Test func moveLeftChangesPosition() {
+        let manager = GameManager()
+        manager.handleAction(.newGame)
+        manager.handleAction(.resume)
+
+        let originalColumn = manager.currentTetromino.position.column
+        manager.handleAction(.moveLeft)
+        #expect(manager.currentTetromino.position.column == originalColumn - 1)
+    }
+
+    @Test func moveRightChangesPosition() {
+        let manager = GameManager()
+        manager.handleAction(.newGame)
+        manager.handleAction(.resume)
+
+        let originalColumn = manager.currentTetromino.position.column
+        manager.handleAction(.moveRight)
+        #expect(manager.currentTetromino.position.column == originalColumn + 1)
+    }
+
+    @Test func moveDoesNothingWhenPaused() {
+        let manager = GameManager()
+        manager.handleAction(.newGame)
+
+        let originalColumn = manager.currentTetromino.position.column
+        manager.handleAction(.moveLeft)
+        #expect(manager.currentTetromino.position.column == originalColumn)
+    }
+
+    @Test func moveDoesNothingWhenGameOver() {
+        let manager = GameManager()
+
+        let originalColumn = manager.currentTetromino.position.column
+        manager.handleAction(.moveLeft)
+        #expect(manager.currentTetromino.position.column == originalColumn)
+    }
+
+    @Test func holdSwapsTetrominoOnFirstHold() {
+        let manager = GameManager()
+        manager.handleAction(.newGame)
+        manager.handleAction(.resume)
+
+        let originalCurrent = manager.currentTetromino
+        manager.handleAction(.hold)
+
+        #expect(manager.heldTetromino?.shape == originalCurrent.shape)
+        #expect(manager.canHoldTetromino == false)
+    }
+
+    @Test func holdCannotBeUsedTwiceWithoutPlacing() {
+        let manager = GameManager()
+        manager.handleAction(.newGame)
+        manager.handleAction(.resume)
+
+        manager.handleAction(.hold)
+        let afterFirstHold = manager.currentTetromino
+        manager.handleAction(.hold)
+        #expect(manager.currentTetromino.shape == afterFirstHold.shape)
+    }
+
+    @Test func rotateChangesTetrominoShape() {
+        let manager = GameManager()
+        manager.handleAction(.newGame)
+        manager.handleAction(.resume)
+
+        let originalState = manager.currentTetromino.rotationState
+        manager.handleAction(.rotate)
+
+        let hasMultipleRotations = manager.currentTetromino.rotations.count > 1
+        if hasMultipleRotations {
+            #expect(manager.currentTetromino.rotationState != originalState)
+        }
+    }
+
+    @Test func rotateDoesNothingWhenNotPlaying() {
+        let manager = GameManager()
+        manager.handleAction(.newGame)
+
+        let originalState = manager.currentTetromino.rotationState
+        manager.handleAction(.rotate)
+        #expect(manager.currentTetromino.rotationState == originalState)
+    }
+
+    @Test func nextTetrominoIsAssigned() {
+        let manager = GameManager()
+        #expect(manager.nextTetromino.shape.isEmpty == false)
+    }
+
+    @Test func currentTetrominoIsAssigned() {
+        let manager = GameManager()
+        #expect(manager.currentTetromino.shape.isEmpty == false)
+    }
+}

--- a/TetrisTests/ModelTests.swift
+++ b/TetrisTests/ModelTests.swift
@@ -1,0 +1,216 @@
+//
+//  ModelTests.swift
+//  TetrisTests
+//
+//  Created by David Solis on 4/11/26.
+//
+
+import Testing
+import SwiftUI
+@testable import Tetris
+
+@Suite("Models")
+struct ModelTests {
+
+    // MARK: - Position
+
+    @Suite("Position")
+    struct PositionTests {
+        @Test func equality() {
+            let a = Position(row: 3, column: 7)
+            let b = Position(row: 3, column: 7)
+            #expect(a == b)
+        }
+
+        @Test func inequality() {
+            let a = Position(row: 3, column: 7)
+            let b = Position(row: 4, column: 7)
+            #expect(a != b)
+        }
+
+        @Test func codableRoundTrip() throws {
+            let original = Position(row: 5, column: 9)
+            let data = try JSONEncoder().encode(original)
+            let decoded = try JSONDecoder().decode(Position.self, from: data)
+            #expect(original == decoded)
+        }
+    }
+
+    // MARK: - GameCell
+
+    @Suite("GameCell")
+    struct GameCellTests {
+        @Test func defaultIsNotFilled() {
+            let cell = GameCell()
+            #expect(cell.isFilled == false)
+            #expect(cell.color == nil)
+        }
+
+        @Test func filledCellRetainsColor() {
+            let color = CustomColor(from: .red)
+            let cell = GameCell(isFilled: true, color: color)
+            #expect(cell.isFilled == true)
+            #expect(cell.color == color)
+        }
+
+        @Test func equality() {
+            let a = GameCell(isFilled: true, color: CustomColor(from: .blue))
+            let b = GameCell(isFilled: true, color: CustomColor(from: .blue))
+            #expect(a == b)
+        }
+
+        @Test func codableRoundTrip() throws {
+            let original = GameCell(isFilled: true, color: CustomColor(from: .green))
+            let data = try JSONEncoder().encode(original)
+            let decoded = try JSONDecoder().decode(GameCell.self, from: data)
+            #expect(original == decoded)
+        }
+    }
+
+    // MARK: - CustomColor
+
+    @Suite("CustomColor")
+    struct CustomColorTests {
+        @Test func codableRoundTrip() throws {
+            let original = CustomColor(from: .cyan)
+            let data = try JSONEncoder().encode(original)
+            let decoded = try JSONDecoder().decode(CustomColor.self, from: data)
+            #expect(original == decoded)
+        }
+
+        @Test func storesRGBComponents() {
+            let color = CustomColor(from: .red)
+            #expect(color.red > 0.9)
+            #expect(color.green < 0.1)
+            #expect(color.blue < 0.1)
+            #expect(color.opacity > 0.9)
+        }
+
+        @Test func equality() {
+            let a = CustomColor(from: .purple)
+            let b = CustomColor(from: .purple)
+            #expect(a == b)
+        }
+
+        @Test func inequality() {
+            let a = CustomColor(from: .red)
+            let b = CustomColor(from: .blue)
+            #expect(a != b)
+        }
+
+        @Test func valueReturnsColor() {
+            let custom = CustomColor(from: .orange)
+            let _ = custom.value // Should not crash
+        }
+    }
+
+    // MARK: - GameState
+
+    @Suite("GameState")
+    struct GameStateTests {
+        @Test(arguments: [GameState.playing, .paused, .gameOver])
+        func codableRoundTrip(state: GameState) throws {
+            let data = try JSONEncoder().encode(state)
+            let decoded = try JSONDecoder().decode(GameState.self, from: data)
+            #expect(state == decoded)
+        }
+    }
+
+    // MARK: - GameSession
+
+    @Suite("GameSession")
+    struct GameSessionTests {
+        @Test func codableRoundTrip() throws {
+            let board: [[GameCell?]] = Array(
+                repeating: Array(repeating: GameCell(), count: 10),
+                count: 20
+            )
+            let original = GameSession(
+                gameBoard: board,
+                score: 500,
+                level: 2,
+                currentTetromino: TetrominoFactory.generate(),
+                nextTetromino: TetrominoFactory.generate(),
+                heldTetromino: nil,
+                canHoldTetromino: true
+            )
+
+            let data = try JSONEncoder().encode(original)
+            let decoded = try JSONDecoder().decode(GameSession.self, from: data)
+
+            #expect(decoded.score == 500)
+            #expect(decoded.level == 2)
+            #expect(decoded.canHoldTetromino == true)
+            #expect(decoded.heldTetromino == nil)
+        }
+
+        @Test func codableRoundTripWithHeldTetromino() throws {
+            let board: [[GameCell?]] = Array(
+                repeating: Array(repeating: GameCell(), count: 10),
+                count: 20
+            )
+            let held = TetrominoFactory.generate()
+            let original = GameSession(
+                gameBoard: board,
+                score: 1200,
+                level: 3,
+                currentTetromino: TetrominoFactory.generate(),
+                nextTetromino: TetrominoFactory.generate(),
+                heldTetromino: held,
+                canHoldTetromino: false
+            )
+
+            let data = try JSONEncoder().encode(original)
+            let decoded = try JSONDecoder().decode(GameSession.self, from: data)
+
+            #expect(decoded.score == 1200)
+            #expect(decoded.level == 3)
+            #expect(decoded.canHoldTetromino == false)
+            #expect(decoded.heldTetromino != nil)
+        }
+    }
+
+    // MARK: - Array Safe Subscript
+
+    @Suite("Array Safe Subscript")
+    struct ArraySafeSubscriptTests {
+        @Test func validIndicesReturnValue() {
+            let grid: [[Int]] = [[1, 2, 3], [4, 5, 6]]
+            #expect(grid[safeRow: 0, safeColumn: 0] == 1)
+            #expect(grid[safeRow: 1, safeColumn: 2] == 6)
+        }
+
+        @Test func negativeRowReturnsNil() {
+            let grid: [[Int]] = [[1, 2], [3, 4]]
+            #expect(grid[safeRow: -1, safeColumn: 0] == nil)
+        }
+
+        @Test func negativeColumnReturnsNil() {
+            let grid: [[Int]] = [[1, 2], [3, 4]]
+            #expect(grid[safeRow: 0, safeColumn: -1] == nil)
+        }
+
+        @Test func rowOutOfBoundsReturnsNil() {
+            let grid: [[Int]] = [[1, 2], [3, 4]]
+            #expect(grid[safeRow: 5, safeColumn: 0] == nil)
+        }
+
+        @Test func columnOutOfBoundsReturnsNil() {
+            let grid: [[Int]] = [[1, 2], [3, 4]]
+            #expect(grid[safeRow: 0, safeColumn: 5] == nil)
+        }
+    }
+
+    // MARK: - PlayerAction
+
+    @Suite("PlayerAction")
+    struct PlayerActionTests {
+        @Test func allCasesAreDistinct() {
+            let actions: [PlayerAction] = [
+                .newGame, .continueGame, .pause, .resume,
+                .moveLeft, .moveRight, .hold, .rotate, .drop
+            ]
+            #expect(actions.count == 9)
+        }
+    }
+}

--- a/TetrisTests/TetrominoFactoryTests.swift
+++ b/TetrisTests/TetrominoFactoryTests.swift
@@ -1,0 +1,72 @@
+//
+//  TetrominoFactoryTests.swift
+//  TetrisTests
+//
+//  Created by David Solis on 4/11/26.
+//
+
+import Testing
+@testable import Tetris
+
+@Suite("Tetromino Factory")
+struct TetrominoFactoryTests {
+
+    @Test func generatesTetrominoWithNonEmptyShape() {
+        let tetromino = TetrominoFactory.generate()
+        #expect(!tetromino.shape.isEmpty)
+        let hasAtLeastOneBlock = tetromino.shape.contains { row in
+            row.contains(true)
+        }
+        #expect(hasAtLeastOneBlock)
+    }
+
+    @Test func generatedTetrominoHasRotations() {
+        let tetromino = TetrominoFactory.generate()
+        #expect(!tetromino.rotations.isEmpty)
+    }
+
+    @Test func generatedTetrominoHasWallKickData() {
+        let tetromino = TetrominoFactory.generate()
+        #expect(!tetromino.wallKickData.isEmpty)
+    }
+
+    @Test func generatedTetrominoStartsAtTopOfBoard() {
+        let tetromino = TetrominoFactory.generate()
+        #expect(tetromino.position.row == 0)
+    }
+
+    @Test func generatedTetrominoStartsNearCenter() {
+        let tetromino = TetrominoFactory.generate()
+        #expect(tetromino.position.column >= 3)
+        #expect(tetromino.position.column <= 5)
+    }
+
+    @Test func generatedTetrominoFitsEmptyBoard() {
+        let board: [[GameCell?]] = Array(
+            repeating: Array(repeating: GameCell(), count: 10),
+            count: 20
+        )
+        let tetromino = TetrominoFactory.generate()
+        #expect(tetromino.fitsWithin(gameBoard: board))
+    }
+
+    @Test func generatedTetrominoStartsAtRotationStateZero() {
+        let tetromino = TetrominoFactory.generate()
+        #expect(tetromino.rotationState == 0)
+    }
+
+    @Test func shapeMatchesFirstRotation() {
+        let tetromino = TetrominoFactory.generate()
+        #expect(tetromino.shape == tetromino.rotations[0])
+    }
+
+    @Test func multipleGenerationsProduceDifferentPieces() {
+        var shapes = Set<String>()
+        for _ in 0..<100 {
+            let tetromino = TetrominoFactory.generate()
+            let description = tetromino.shape.description
+            shapes.insert(description)
+        }
+        #expect(shapes.count > 1)
+    }
+}

--- a/TetrisTests/TetrominoTests.swift
+++ b/TetrisTests/TetrominoTests.swift
@@ -1,0 +1,118 @@
+//
+//  TetrominoTests.swift
+//  TetrisTests
+//
+//  Created by David Solis on 4/11/26.
+//
+
+import Testing
+@testable import Tetris
+
+@Suite("Tetromino")
+struct TetrominoTests {
+
+    let emptyBoard: [[GameCell?]] = Array(
+        repeating: Array(repeating: GameCell(), count: 10),
+        count: 20
+    )
+
+    @Test func fitsWithinEmptyBoard() {
+        let tetromino = TetrominoFactory.generate()
+        #expect(tetromino.fitsWithin(gameBoard: emptyBoard))
+    }
+
+    @Test func doesNotFitBelowBoard() {
+        var tetromino = TetrominoFactory.generate()
+        tetromino.position = Position(row: 20, column: 4)
+        #expect(!tetromino.fitsWithin(gameBoard: emptyBoard))
+    }
+
+    @Test func doesNotFitLeftOfBoard() {
+        var tetromino = TetrominoFactory.generate()
+        tetromino.position = Position(row: 0, column: -5)
+        #expect(!tetromino.fitsWithin(gameBoard: emptyBoard))
+    }
+
+    @Test func doesNotFitRightOfBoard() {
+        var tetromino = TetrominoFactory.generate()
+        tetromino.position = Position(row: 0, column: 12)
+        #expect(!tetromino.fitsWithin(gameBoard: emptyBoard))
+    }
+
+    @Test func doesNotFitOnFilledCell() {
+        var board = emptyBoard
+        board[1][4] = GameCell(isFilled: true, color: CustomColor(from: .red))
+
+        let tetromino = Tetromino(
+            shape: [[true]],
+            color: CustomColor(from: .blue),
+            position: Position(row: 1, column: 4),
+            rotations: [[[true]]],
+            wallKickData: [[Position(row: 0, column: 0)]]
+        )
+        #expect(!tetromino.fitsWithin(gameBoard: board))
+    }
+
+    @Test func fitsOnEmptyCellNextToFilledCell() {
+        var board = emptyBoard
+        board[1][4] = GameCell(isFilled: true, color: CustomColor(from: .red))
+
+        let tetromino = Tetromino(
+            shape: [[true]],
+            color: CustomColor(from: .blue),
+            position: Position(row: 1, column: 5),
+            rotations: [[[true]]],
+            wallKickData: [[Position(row: 0, column: 0)]]
+        )
+        #expect(tetromino.fitsWithin(gameBoard: board))
+    }
+
+    @Test func rotationChangesShape() {
+        var tetromino = Tetromino(
+            shape: [
+                [false, true, false],
+                [true, true, true],
+                [false, false, false]
+            ],
+            color: CustomColor(from: .purple),
+            position: Position(row: 5, column: 4),
+            rotations: [
+                [[false, true, false], [true, true, true], [false, false, false]],
+                [[false, true], [true, true], [false, true]],
+                [[false, false, false], [true, true, true], [false, true, false]],
+                [[true, false], [true, true], [true, false]]
+            ],
+            wallKickData: [
+                [Position(row: 0, column: 0)],
+                [Position(row: 0, column: 0)],
+                [Position(row: 0, column: 0)],
+                [Position(row: 0, column: 0)]
+            ]
+        )
+
+        let originalShape = tetromino.shape
+        tetromino.rotate(gameBoard: emptyBoard)
+        #expect(tetromino.shape != originalShape)
+        #expect(tetromino.rotationState == 1)
+    }
+
+    @Test func rotationCyclesBackToOriginal() {
+        var tetromino = Tetromino(
+            shape: [[true, true], [true, true]],
+            color: CustomColor(from: .yellow),
+            position: Position(row: 5, column: 4),
+            rotations: [[[true, true], [true, true]]],
+            wallKickData: [[Position(row: 0, column: 0)]]
+        )
+
+        let originalShape = tetromino.shape
+        tetromino.rotate(gameBoard: emptyBoard)
+        #expect(tetromino.shape == originalShape)
+    }
+
+    @Test func identifiableHasUniqueIds() {
+        let a = TetrominoFactory.generate()
+        let b = TetrominoFactory.generate()
+        #expect(a.id != b.id)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a **TetrisTests** target using Apple's Swift Testing framework (`import Testing`)
- 4 test files with **40+ tests** covering all major components:
  - **TetrominoTests**: Board fitting, boundary checks, rotation, wall kicks, identity
  - **GameManagerTests**: State machine (gameOver/paused/playing), movement, hold, rotation, score/level
  - **TetrominoFactoryTests**: Generation validity, positions, shape diversity, rotation state
  - **ModelTests**: Position, GameCell, CustomColor, GameState (parameterized), GameSession codable round-trips, Array safe subscript bounds checking, PlayerAction completeness
- Uses Swift Testing features: `@Suite`, `@Test`, `#expect`, `@Test(arguments:)` parameterized tests, `@MainActor` isolation

## Test plan
- [ ] Open in Xcode 26 and run the TetrisTests scheme
- [ ] Verify all tests pass (Product > Test or Cmd+U)
- [ ] Confirm test navigator shows the organized suite hierarchy

Generated with [Claude Code](https://claude.com/claude-code)