### PR TITLE
Fix CustomColor test using explicit sRGB red

### DIFF
--- a/TetrisTests/ModelTests.swift
+++ b/TetrisTests/ModelTests.swift
@@ -79,7 +79,7 @@ struct ModelTests {
         }
 
         @Test func storesRGBComponents() {
-            let color = CustomColor(from: .red)
+            let color = CustomColor(from: Color(red: 1.0, green: 0.0, blue: 0.0))
             #expect(color.red > 0.9)
             #expect(color.green < 0.1)
             #expect(color.blue < 0.1)


### PR DESCRIPTION
## Summary
- Fix failing `storesRGBComponents` test by using `Color(red: 1.0, green: 0.0, blue: 0.0)` instead of `Color.red`
- SwiftUI's `.red` is a system color (`UIColor.systemRed`) that resolves to ~(1.0, 0.23, 0.19), causing the `green < 0.1` and `blue < 0.1` assertions to fail

## Test plan
- [ ] Run `storesRGBComponents` test — should now pass

Generated with [Claude Code](https://claude.com/claude-code)