### PR TITLE
Fix tetromino preview alignment within glass containers

### DIFF
--- a/Tetris/View/TetrominoPreview.swift
+++ b/Tetris/View/TetrominoPreview.swift
@@ -36,8 +36,10 @@ struct TetrominoPreview: View {
                     }
                 }
             }
+            .frame(width: boardWidth, height: boardHeight)
         }
         .frame(width: 100, height: 100)
+        .clipped()
         .glassEffect(.regular, in: .rect(cornerRadius: 16))
     }
 }


### PR DESCRIPTION
## Summary
- The ZStack inside TetrominoPreview had no size anchor after the opaque background rectangle was removed for the Liquid Glass redesign
- Without a frame, the ZStack collapsed to just its children's size and sat at the GeometryReader's top-left origin, causing pieces to overflow outside the glass containers
- Added `.frame(width: boardWidth, height: boardHeight)` to the ZStack and `.clipped()` to prevent overflow

## Test plan
- [ ] Verify hold and next piece previews are centered within their glass containers
- [ ] Check all 7 piece types render correctly in the preview

Generated with [Claude Code](https://claude.com/claude-code)