### PR TITLE
Fix hold piece tap gesture

### DIFF
--- a/Tetris/View/TetrominoPreview.swift
+++ b/Tetris/View/TetrominoPreview.swift
@@ -39,6 +39,7 @@ struct TetrominoPreview: View {
             .frame(width: boardWidth, height: boardHeight)
         }
         .frame(width: 100, height: 100)
+        .contentShape(Rectangle())
         .clipped()
         .glassEffect(.regular, in: .rect(cornerRadius: 16))
     }


### PR DESCRIPTION
## Summary
- Add `.contentShape(Rectangle())` to `TetrominoPreview` so the entire view area registers taps, even when the inner `ZStack` is empty (no held piece yet)
- Without this, SwiftUI skips hit-testing on transparent regions, causing taps on the hold piece view to pass through

## Test plan
- [ ] Tap the hold piece view (top left) during gameplay — it should hold/swap the current piece
- [ ] Verify tapping works both when the hold view is empty and when it already contains a piece

🤖 Generated with [Claude Code](https://claude.com/claude-code)